### PR TITLE
Hotfix: Docs GH Action Looping Infinitely

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,6 @@
 # This workflow will install Python dependencies and generate Markdown
 # documentation from docstrings using Sphinx. We generate the HTML
 # documentation to keep it up to date with the Markdown files
-
 name: Python Library API docs
 
 on:
@@ -9,12 +8,14 @@ on:
     branches:
       - main
       - release-v1
+    paths-ignore:
+      - 'docs/_build/**'
   workflow_dispatch:
     inputs:
       note:
-        description: "Provide a description of the changes"
+        description: 'Provide a description of the changes'
         required: true
-        default: "Update docs"
+        default: 'Update docs'
 
 permissions:
   contents: write
@@ -35,8 +36,8 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-          cache: "poetry"
+          python-version: '3.11'
+          cache: 'poetry'
 
       - name: Install Dependencies
         run: |
@@ -52,5 +53,5 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           default_author: github_actions
-          message: "Generate docs"
-          add: "docs/_build/"
+          message: 'Generate docs'
+          add: 'docs/_build/'


### PR DESCRIPTION
## Internal Notes for Reviewers

Adding a `paths-ignore` clause to stop the docs GH action from running if the only changes are to the docs build folder.


<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->