### PR TITLE
[SC-7553] Fix error in comparison tests when not using parameters

### DIFF
--- a/notebooks/how_to/run_tests/2_run_comparison_tests.ipynb
+++ b/notebooks/how_to/run_tests/2_run_comparison_tests.ipynb
@@ -130,7 +130,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q validmind"
+    "#%pip install -q validmind\n",
+    "%pip install -q ../../../../developer-framework"
    ]
   },
   {
@@ -172,11 +173,33 @@
     "import validmind as vm\n",
     "\n",
     "vm.init(\n",
-    "    api_host=\"https://api.prod.validmind.ai/api/v1/tracking\",\n",
-    "    api_key=\"...\",\n",
-    "    api_secret=\"...\",\n",
-    "    model=\"...\",\n",
+    "  api_host = \"https://api.prod.validmind.ai/api/v1/tracking\",\n",
+    "  api_key = \"...\",\n",
+    "  api_secret = \"...\",\n",
+    "  model = \"...\"\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='toc4_'></a>\n",
+    "\n",
+    "## Initialize the Python environment\n",
+    "\n",
+    "Next, let's import the necessary libraries and set up your Python environment for data analysis:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xgboost as xgb\n",
+    "\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -324,10 +347,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xgboost as xgb\n",
-    "\n",
-    "%matplotlib inline\n",
-    "\n",
     "x_train = train_df.drop(customer_churn.target_column, axis=1)\n",
     "y_train = train_df[customer_churn.target_column]\n",
     "x_val = validation_df.drop(customer_churn.target_column, axis=1)\n",
@@ -358,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/how_to/run_tests/2_run_comparison_tests.ipynb
+++ b/notebooks/how_to/run_tests/2_run_comparison_tests.ipynb
@@ -130,8 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%pip install -q validmind\n",
-    "%pip install -q ../../../../developer-framework"
+    "%pip install -q validmind"
    ]
   },
   {

--- a/notebooks/how_to/run_unit_metrics.ipynb
+++ b/notebooks/how_to/run_unit_metrics.ipynb
@@ -491,7 +491,7 @@
     "    result.log()\n",
     "\n",
     "    # instead of showing the widget, we can print the result value\n",
-    "    print(f\"{metric_id}: {result.scalar}\")"
+    "    print(f\"{metric_id}: {result.metric}\")"
    ]
   },
   {

--- a/validmind/tests/comparison.py
+++ b/validmind/tests/comparison.py
@@ -328,8 +328,10 @@ def combine_results(
                 if isinstance(input_obj_or_list, list)
                 else [input_obj_or_list]
             )
-        for param_name, param_value in result.params.items():
-            combined_params.setdefault(param_name, []).append(param_value)
+        # Handle when there are no params
+        if result.params:
+            for param_name, param_value in result.params.items():
+                combined_params.setdefault(param_name, []).append(param_value)
 
     combined_inputs = _combine_dict_values(combined_inputs)
     combined_params = _combine_dict_values(combined_params)

--- a/validmind/tests/decorator.py
+++ b/validmind/tests/decorator.py
@@ -2,7 +2,7 @@
 # See the LICENSE file in the root of this repository for details.
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 
-"""Decorators for creating and registering metrics with the ValidMind Library."""
+"""Decorators for creating and registering tests with the ValidMind Library."""
 
 import inspect
 import os
@@ -83,21 +83,25 @@ def _get_save_func(func, test_id):
 
 
 def test(func_or_id):
-    """Decorator for creating and registering metrics with the ValidMind Library.
+    """Decorator for creating and registering custom tests
 
-    Creates a metric object and registers it with ValidMind under the provided ID. If
-    no ID is provided, the function name will be used as to build one. So if the
-    function name is `my_metric`, the metric will be registered under the ID
-    `validmind.custom_metrics.my_metric`.
+    This decorator registers the function it wraps as a test function within ValidMind
+    under the provided ID. Once decorated, the function can be run using the
+    `validmind.tests.run_test` function.
 
-    This decorator works by creating a new `Metric` class will be created whose `run`
-    method calls the decorated function. This function should take as arguments the
-    inputs it requires (`dataset`, `datasets`, `model`, `models`) followed by any
-    parameters. It can return any number of the following types:
+    The function can take two different types of arguments:
+
+    - Inputs: ValidMind model or dataset (or list of models/datasets). These arguments
+      must use the following names: `model`, `models`, `dataset`, `datasets`.
+    - Parameters: Any additional keyword arguments of any type (must have a default
+      value) that can have any name.
+
+    The function should return one of the following types:
 
     - Table: Either a list of dictionaries or a pandas DataFrame
     - Plot: Either a matplotlib figure or a plotly figure
-    - Scalar: A single number or string
+    - Scalar: A single number (int or float)
+    - Boolean: A single boolean value indicating whether the test passed or failed
 
     The function may also include a docstring. This docstring will be used and logged
     as the metric's description.
@@ -131,10 +135,10 @@ def test(func_or_id):
 
 
 def tasks(*tasks):
-    """Decorator for specifying the task types that a metric is designed for.
+    """Decorator for specifying the task types that a test is designed for.
 
     Args:
-        *tasks: The task types that the metric is designed for.
+        *tasks: The task types that the test is designed for.
     """
 
     def decorator(func):
@@ -145,10 +149,10 @@ def tasks(*tasks):
 
 
 def tags(*tags):
-    """Decorator for specifying tags for a metric.
+    """Decorator for specifying tags for a test.
 
     Args:
-        *tags: The tags to apply to the metric.
+        *tags: The tags to apply to the test.
     """
 
     def decorator(func):

--- a/validmind/unit_metrics/__init__.py
+++ b/validmind/unit_metrics/__init__.py
@@ -12,7 +12,11 @@ def list_metrics(**kwargs):
     vm_provider = test_provider_store.get_test_provider("validmind")
     vm_metrics_provider = vm_provider.metrics_provider
 
-    return vm_metrics_provider.list_tests(**kwargs)
+    prefix = "validmind.unit_metrics."
+
+    return [
+        f"{prefix}{test_id}" for test_id in vm_metrics_provider.list_tests(**kwargs)
+    ]
 
 
 def describe_metric(metric_id: str, **kwargs):

--- a/validmind/vm_models/test_suite/test.py
+++ b/validmind/vm_models/test_suite/test.py
@@ -76,9 +76,8 @@ class TestSuiteTest:
             def run_test_with_logging():
                 return run_test(
                     self.test_id,
-                    generate_description=False,
-                    show=False,
                     **(config or {}),
+                    show=False,
                 )
 
             self.result = run_test_with_logging()


### PR DESCRIPTION
## Internal Notes for Reviewers
The `combine_results()` function in `validmind/tests/comparison.py` fails with an `AttributeError` when processing test results that don't have parameters. 

Fix: Add null checks before accessing `result.params` to handle running comparison tests that don't specify parameters.

I also moved the import of XGBoost to the top in a separate cell in `2_run_comparison_tests.ipynb`, as the model fitting was causing a strange Jupyter crash. However, when I moved it to a separate cell, it worked. Not sure why, though.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->