### PR TITLE
feat: add print_env function

### DIFF
--- a/validmind/__init__.py
+++ b/validmind/__init__.py
@@ -50,6 +50,7 @@ from .client import (  # noqa: E402
     run_test_suite,
 )
 from .tests.decorator import tags, tasks, test
+from .tests.run import print_env
 from .vm_models.result import RawData
 
 __all__ = [  # noqa
@@ -63,6 +64,7 @@ __all__ = [  # noqa
     "init_model",
     "init_r_model",
     "preview_template",
+    "print_env",
     "RawData",
     "reload",
     "run_documentation_tests",

--- a/validmind/tests/run.py
+++ b/validmind/tests/run.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 from datetime import datetime
 from inspect import getdoc
+import pprint
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
@@ -396,3 +397,7 @@ def run_test(  # noqa: C901
         result.show()
 
     return result
+
+def print_env():
+    e = _get_run_metadata()
+    pprint.pp(e)


### PR DESCRIPTION
## Internal Notes for Reviewers

Usage and output:

```
{'validmind': {'version': '2.7.7'},
 'python': {'version': '3.11.11',
            'implementation': 'CPython',
            'compiler': 'GCC 14.2.1 20240910'},
 'platform': 'Linux-6.12.8-arch1-1-x86_64-with-glibc2.40',
 'pip': {'aiodns': '3.2.0',
         'aiohappyeyeballs': '2.4.4',
         'aiohttp': '3.10.11',
         'aiosignal': '1.3.1',
         'alabaster': '0.7.13',
         'annotated-types': '0.7.0',
         'ansicolors': '1.1.8',
         'anyio': '4.5.2',
         'arch': '5.6.0',
         'argon2-cffi': '23.1.0',
         'argon2-cffi-bindings': '21.2.0',
         'arrow': '1.3.0',
         'asttokens': '3.0.0',
         'async-lru': '2.0.4',
         'attrs': '24.3.0',
         'babel': '2.16.0',
         'backcall': '0.2.0',
         'backports.tarfile': '1.2.0',
         'beautifulsoup4': '4.12.3',
         'bert-score': '0.3.13',
         'black': '22.12.0',
         'bleach': '6.1.0',
         'Brotli': '1.1.0',
         'catboost': '1.2.7',
         'certifi': '2024.12.14',
         'cffi': '1.17.1',
         'cfgv': '3.4.0',
         'charset-normalizer': '3.4.1',
         'click': '8.1.8',
         'cloudpickle': '3.1.0',
         'comm': '0.2.2',
         'contourpy': '1.1.1',
         'cryptography': '43.0.3',
         'cycler': '0.12.1',
         'Cython': '0.29.37',
         'dacite': '1.8.1',
         'datasets': '2.21.0',
         'debugpy': '1.8.11',
         'decorator': '5.1.1',
         'defusedxml': '0.7.1',
         'dill': '0.3.8',
         'distlib': '0.3.9',
         'distro': '1.9.0',
         'docutils': '0.18.1',
         'entrypoints': '0.4',
         'evaluate': '0.4.3',
         'executing': '2.1.0',
         'fastjsonschema': '2.21.1',
         'filelock': '3.16.1',
         'flake8': '4.0.1',
         'fonttools': '4.55.3',
         'fqdn': '1.5.1',
         'frozendict': '2.4.6',
         'frozenlist': '1.5.0',
         'fsspec': '2024.6.1',
         'graphviz': '0.20.3',
         'h11': '0.14.0',
         'html2text': '2024.2.26',
         'html5lib': '1.1',
         'htmlmin': '0.1.12',
         'httpcore': '1.0.7',
         'httpx': '0.28.1',
         'huggingface-hub': '0.27.1',
         'identify': '2.6.1',
         'idna': '3.10',
         'ImageHash': '4.3.1',
         'imagesize': '1.4.1',
         'importlib_metadata': '8.5.0',
         'ipykernel': '6.29.5',
         'ipython': '8.12.3',
         'ipywidgets': '8.1.5',
         'isoduration': '20.11.0',
         'isort': '5.13.2',
         'jaraco.classes': '3.4.0',
         'jaraco.context': '6.0.1',
         'jaraco.functools': '4.1.0',
         'jedi': '0.19.2',
         'jeepney': '0.8.0',
         'Jinja2': '3.1.5',
         'jiter': '0.8.2',
         'joblib': '1.4.2',
         'json5': '0.10.0',
         'jsonpointer': '3.0.0',
         'jsonschema': '4.23.0',
         'jsonschema-specifications': '2023.12.1',
         'jupyter': '1.1.1',
         'jupyter-console': '6.6.3',
         'jupyter-events': '0.10.0',
         'jupyter-lsp': '2.2.5',
         'jupyter_client': '8.6.3',
         'jupyter_core': '5.7.2',
         'jupyter_server': '2.14.2',
         'jupyter_server_terminals': '0.5.3',
         'jupyterlab': '4.3.4',
         'jupyterlab_pygments': '0.3.0',
         'jupyterlab_server': '2.27.3',
         'jupyterlab_widgets': '3.0.13',
         'kaleido': '0.2.1',
         'keyring': '25.5.0',
         'kiwisolver': '1.4.7',
         'langdetect': '1.0.9',
         'latex2mathml': '3.77.0',
         'llvmlite': '0.41.1',
         'lxml': '5.3.0',
         'markdown-it-py': '3.0.0',
         'MarkupSafe': '2.1.5',
         'matplotlib': '3.7.5',
         'matplotlib-inline': '0.1.7',
         'mccabe': '0.6.1',
         'mdurl': '0.1.2',
         'mistune': '3.1.0',
         'more-itertools': '10.5.0',
         'mpmath': '1.3.0',
         'multidict': '6.1.0',
         'multimethod': '1.10',
         'multiprocess': '0.70.16',
         'multitasking': '0.0.11',
         'mypy-extensions': '1.0.0',
         'nbclient': '0.10.1',
         'nbconvert': '7.16.5',
         'nbformat': '5.10.4',
         'nest-asyncio': '1.6.0',
         'networkx': '3.1',
         'nh3': '0.2.20',
         'nltk': '3.9.1',
         'nodeenv': '1.9.1',
         'notebook': '7.3.2',
         'notebook_shim': '0.2.4',
         'numba': '0.58.1',
         'numpy': '1.24.4',
         'nvidia-cublas-cu12': '12.4.5.8',
         'nvidia-cuda-cupti-cu12': '12.4.127',
         'nvidia-cuda-nvrtc-cu12': '12.4.127',
         'nvidia-cuda-runtime-cu12': '12.4.127',
         'nvidia-cudnn-cu12': '9.1.0.70',
         'nvidia-cufft-cu12': '11.2.1.3',
         'nvidia-curand-cu12': '10.3.5.147',
         'nvidia-cusolver-cu12': '11.6.1.9',
         'nvidia-cusparse-cu12': '12.3.1.170',
         'nvidia-nccl-cu12': '2.21.5',
         'nvidia-nvjitlink-cu12': '12.4.127',
         'nvidia-nvtx-cu12': '12.4.127',
         'openai': '1.59.6',
         'overrides': '7.7.0',
         'packaging': '24.2',
         'pandas': '2.0.3',
         'pandocfilters': '1.5.1',
         'papermill': '2.6.0',
         'parso': '0.8.4',
         'pathspec': '0.12.1',
         'patsy': '1.0.1',
         'pdoc': '14.7.0',
         'peewee': '3.17.8',
         'pexpect': '4.9.0',
         'phik': '0.12.4',
         'pickleshare': '0.7.5',
         'pillow': '10.4.0',
         'pkginfo': '1.12.0',
         'platformdirs': '4.3.6',
         'plotly': '5.24.1',
         'plotly-express': '0.4.1',
         'polars': '1.8.2',
         'pre-commit': '3.5.0',
         'prometheus_client': '0.21.1',
         'prompt_toolkit': '3.0.48',
         'propcache': '0.2.0',
         'property-cached': '1.6.4',
         'psutil': '6.1.1',
         'ptyprocess': '0.7.0',
         'pure_eval': '0.2.3',
         'pyarrow': '17.0.0',
         'pycares': '4.4.0',
         'pycodestyle': '2.8.0',
         'pycparser': '2.22',
         'pydantic': '2.10.5',
         'pydantic_core': '2.27.2',
         'pydash': '8.0.4',
         'pyflakes': '2.4.0',
         'Pygments': '2.19.1',
         'pyparsing': '3.1.4',
         'python-dateutil': '2.9.0.post0',
         'python-dotenv': '1.0.1',
         'python-json-logger': '3.2.1',
         'pytz': '2024.2',
         'PyWavelets': '1.4.1',
         'PyYAML': '6.0.2',
         'pyzmq': '26.2.0',
         'readme_renderer': '43.0',
         'referencing': '0.35.1',
         'regex': '2024.11.6',
         'requests': '2.32.3',
         'requests-toolbelt': '1.0.0',
         'rfc3339-validator': '0.1.4',
         'rfc3986': '2.0.0',
         'rfc3986-validator': '0.1.1',
         'rich': '13.9.4',
         'rouge': '1.0.1',
         'rpds-py': '0.20.1',
         'safetensors': '0.5.2',
         'scikit-learn': '1.3.2',
         'scipy': '1.10.1',
         'scorecardpy': '0.1.9.7',
         'seaborn': '0.13.2',
         'SecretStorage': '3.3.3',
         'Send2Trash': '1.8.3',
         'sentry-sdk': '1.45.1',
         'shap': '0.44.1',
         'six': '1.17.0',
         'slicer': '0.0.7',
         'sniffio': '1.3.1',
         'snowballstemmer': '2.2.0',
         'soupsieve': '2.6',
         'Sphinx': '6.2.1',
         'sphinx-markdown-builder': '0.5.5',
         'sphinx-rtd-theme': '1.3.0',
         'sphinxcontrib-applehelp': '1.0.4',
         'sphinxcontrib-devhelp': '1.0.2',
         'sphinxcontrib-htmlhelp': '2.0.1',
         'sphinxcontrib-jquery': '4.1',
         'sphinxcontrib-jsmath': '1.0.1',
         'sphinxcontrib-qthelp': '1.0.3',
         'sphinxcontrib-serializinghtml': '1.1.5',
         'stack-data': '0.6.3',
         'statsmodels': '0.14.1',
         'sympy': '1.13.1',
         'tabulate': '0.8.10',
         'tenacity': '8.5.0',
         'terminado': '0.18.1',
         'textblob': '0.18.0.post0',
         'threadpoolctl': '3.5.0',
         'tinycss2': '1.2.1',
         'tokenizers': '0.20.3',
         'torch': '2.5.1',
         'tornado': '6.4.2',
         'tqdm': '4.67.1',
         'traitlets': '5.14.3',
         'transformers': '4.46.3',
         'triton': '3.1.0',
         'twine': '4.0.2',
         'typeguard': '4.4.0',
         'types-python-dateutil': '2.9.0.20241206',
         'typing_extensions': '4.12.2',
         'tzdata': '2024.2',
         'unify': '0.5',
         'untokenize': '0.1.1',
         'uri-template': '1.3.0',
         'urllib3': '2.2.3',
         'virtualenv': '20.28.1',
         'visions': '0.7.6',
         'wcwidth': '0.2.13',
         'webcolors': '24.8.0',
         'webencodings': '0.5.1',
         'websocket-client': '1.8.0',
         'widgetsnbextension': '4.0.13',
         'wordcloud': '1.9.4',
         'xgboost': '2.1.3',
         'xxhash': '3.5.0',
         'yapf': '0.43.0',
         'yarl': '1.15.2',
         'ydata-profiling': '4.12.1',
         'yfinance': '0.2.51',
         'zipp': '3.20.2'},
 'timestamp': '2025-01-16T13:47:04.778970'}
```

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->