### PR TITLE
[SC 8504] Missing definition of the parameters in the capital markets model notebook

### DIFF
--- a/notebooks/code_samples/capital_markets/quickstart_option_pricing_models.ipynb
+++ b/notebooks/code_samples/capital_markets/quickstart_option_pricing_models.ipynb
@@ -443,6 +443,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "N = 10000\n",
+    "M = 100\n",
+    "\n",
     "# Parameters for synthetic data\n",
     "S0 = 100\n",
     "K = 100\n",


### PR DESCRIPTION
## Internal Notes for Reviewers
* Fix notebook `quickstart_option_pricing_models.ipynb`