### PR TITLE
+`breaking-changes` tag to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ PR instructions for release notes:
 - `enhancement`
 - `bug`
 - `chore`
+- `breaking-change`
 - `deprecation`
 - `documentation`
 


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-8459

Adding a `breaking-change` tag to the `validmind-library` so we can easily collate these in future release notes.