### PR TITLE
[SC 8805] support config option for logging test results

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -201,6 +201,7 @@ class TestAPIClient(unittest.TestCase):
             "inputs": ["input1"],
             "passed": True,
             "summary": [{"key": "value"}],
+            "config": None,
         }
 
         mock_post.return_value = MockAsyncResponse(200, json={"cuid": "abc1234"})

--- a/validmind/api_client.py
+++ b/validmind/api_client.py
@@ -330,6 +330,8 @@ async def alog_test_result(
     result: Dict[str, Any],
     section_id: str = None,
     position: int = None,
+    unsafe: bool = False,
+    config: Dict[str, bool] = None,
 ) -> Dict[str, Any]:
     """Logs test results information
 
@@ -357,7 +359,7 @@ async def alog_test_result(
             "log_test_results",
             params=request_params,
             data=json.dumps(
-                result,
+                {**result, "config": config},
                 cls=NumpyEncoder,
                 allow_nan=False,
             ),

--- a/validmind/api_client.py
+++ b/validmind/api_client.py
@@ -412,7 +412,6 @@ async def alog_metric(
     value: Union[int, float],
     inputs: Optional[List[str]] = None,
     params: Optional[Dict[str, Any]] = None,
-    config: Optional[Dict[str, Any]] = None,
     recorded_at: Optional[str] = None,
     thresholds: Optional[Dict[str, Any]] = None,
 ):
@@ -441,7 +440,6 @@ async def alog_metric(
                     "value": value,
                     "inputs": inputs or [],
                     "params": params or {},
-                    "config": config or {},
                     "recorded_at": recorded_at,
                     "thresholds": thresholds or {},
                 },
@@ -459,7 +457,6 @@ def log_metric(
     value: float,
     inputs: Optional[List[str]] = None,
     params: Optional[Dict[str, Any]] = None,
-    config: Optional[Dict[str, Any]] = None,
     recorded_at: Optional[str] = None,
     thresholds: Optional[Dict[str, Any]] = None,
 ):
@@ -470,11 +467,8 @@ def log_metric(
         value (Union[int, float]): The metric value
         inputs (List[str], optional): List of input IDs
         params (Dict[str, Any], optional): Parameters used to generate the metric
-        config (Dict[str, bool], optional): Configuration options for displaying the metric
     """
-    return run_async(
-        alog_metric, key=key, value=value, inputs=inputs, params=params, config=config
-    )
+    return run_async(alog_metric, key=key, value=value, inputs=inputs, params=params)
 
 
 def get_ai_key() -> Dict[str, Any]:

--- a/validmind/api_client.py
+++ b/validmind/api_client.py
@@ -412,6 +412,7 @@ async def alog_metric(
     value: Union[int, float],
     inputs: Optional[List[str]] = None,
     params: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
     recorded_at: Optional[str] = None,
     thresholds: Optional[Dict[str, Any]] = None,
 ):
@@ -440,6 +441,7 @@ async def alog_metric(
                     "value": value,
                     "inputs": inputs or [],
                     "params": params or {},
+                    "config": config or {},
                     "recorded_at": recorded_at,
                     "thresholds": thresholds or {},
                 },
@@ -457,27 +459,22 @@ def log_metric(
     value: float,
     inputs: Optional[List[str]] = None,
     params: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
     recorded_at: Optional[str] = None,
     thresholds: Optional[Dict[str, Any]] = None,
 ):
-    """Logs a unit metric
-
-    Unit metrics are key-value pairs where the key is the metric name and the value is
-    a scalar (int or float). These key-value pairs are associated with the currently
-    selected model (inventory model in the ValidMind Platform) and keys can be logged
-    to over time to create a history of the metric. On the ValidMind Platform, these metrics
-    will be used to create plots/visualizations for documentation and dashboards etc.
+    """Log a metric
 
     Args:
         key (str): The metric key
-        value (float): The metric value
-        inputs (list, optional): A list of input IDs that were used to compute the metric.
-        params (dict, optional): Dictionary of parameters used to compute the metric.
-        recorded_at (str, optional): The timestamp of the metric. Server will use
-            current time if not provided.
-        thresholds (dict, optional): Dictionary of thresholds for the metric.
+        value (Union[int, float]): The metric value
+        inputs (List[str], optional): List of input IDs
+        params (Dict[str, Any], optional): Parameters used to generate the metric
+        config (Dict[str, bool], optional): Configuration options for displaying the metric
     """
-    run_async(alog_metric, key, value, inputs, params, recorded_at, thresholds)
+    return run_async(
+        alog_metric, key=key, value=value, inputs=inputs, params=params, config=config
+    )
 
 
 def get_ai_key() -> Dict[str, Any]:

--- a/validmind/errors.py
+++ b/validmind/errors.py
@@ -129,6 +129,14 @@ class InvalidInputError(BaseError):
     pass
 
 
+class InvalidParameterError(BaseError):
+    """
+    When an invalid parameter is provided.
+    """
+
+    pass
+
+
 class InvalidTextObjectError(APIRequestError):
     """
     When an invalid Metadat (Text) object is sent to the API.

--- a/validmind/vm_models/result/result.py
+++ b/validmind/vm_models/result/result.py
@@ -442,7 +442,6 @@ class TestResult(Result):
                     value=self.metric,
                     inputs=[input.input_id for input in self._get_flat_inputs()],
                     params=self.params,
-                    config=config,
                 )
             )
 

--- a/validmind/vm_models/result/result.py
+++ b/validmind/vm_models/result/result.py
@@ -443,6 +443,7 @@ class TestResult(Result):
                     value=self.metric,
                     inputs=[input.input_id for input in self._get_flat_inputs()],
                     params=self.params,
+                    config=config,
                 )
             )
 

--- a/validmind/vm_models/result/result.py
+++ b/validmind/vm_models/result/result.py
@@ -447,17 +447,8 @@ class TestResult(Result):
             )
 
         if self.tables or self.figures:
-            # # Include config in the serialized result instead of as a separate parameter
-            # result_data = self.serialize()
-            # if config:
-            #     # Add config to metadata if it exists, or create metadata
-            #     if "metadata" not in result_data or result_data["metadata"] is None:
-            #         result_data["metadata"] = {}
-            #     result_data["metadata"]["display_config"] = config
-
             tasks.append(
                 api_client.alog_test_result(
-                    # result=result_data,
                     result=self.serialize(),
                     section_id=section_id,
                     position=position,

--- a/validmind/vm_models/result/result.py
+++ b/validmind/vm_models/result/result.py
@@ -427,7 +427,6 @@ class TestResult(Result):
         self,
         section_id: str = None,
         position: int = None,
-        unsafe: bool = False,
         config: Dict[str, bool] = None,
     ):
         tasks = []  # collect tasks to run in parallel (async)
@@ -453,7 +452,6 @@ class TestResult(Result):
                     result=self.serialize(),
                     section_id=section_id,
                     position=position,
-                    unsafe=unsafe,
                     config=config,
                 )
             )
@@ -518,7 +516,6 @@ class TestResult(Result):
             self.log_async,
             section_id=section_id,
             position=position,
-            unsafe=unsafe,
             config=config,
         )
 


### PR DESCRIPTION
## Internal Notes for Reviewers
We now have configuration options that can be passed through `result.log()` to display and customize the test results block in UI documents.

Available config options:
    - hideTitle
    - hideText
    - hideParams
    - hideTables
    - hideFigures
   
```python
test = vm.tests.run_test(
    "validmind.data_validation.TabularDescriptionTables:raw_dataset",
    input_grid={
        "dataset": [vm_raw_dataset],
    },
)
test.log(config={"hideFigures": False, "hideTables": True})
```

## External Release Notes
We now have configuration options that can be passed through `result.log()` to display and customize the test results block in UI documents.

Available config options:
    - hideTitle
    - hideText
    - hideParams
    - hideTables
    - hideFigures
   
```python
test = vm.tests.run_test(
    "validmind.data_validation.TabularDescriptionTables:raw_dataset",
    input_grid={
        "dataset": [vm_raw_dataset],
    },
)
test.log(config={"hideFigures": False, "hideTables": True})
```

