### PR TITLE
[SC-9442] Fix param_grid showing duplicated combinations and missing parameters in figure titles

### DIFF
--- a/validmind/tests/run.py
+++ b/validmind/tests/run.py
@@ -222,6 +222,7 @@ def _run_comparison_test(
     params: Union[Dict[str, Any], None],
     param_grid: Union[Dict[str, List[Any]], List[Dict[str, Any]], None],
     title: Optional[str] = None,
+    show_params: bool = True,
 ):
     """Run a comparison test i.e. a test that compares multiple outputs of a test across
     different input and/or param combinations"""
@@ -242,6 +243,7 @@ def _run_comparison_test(
             show=False,
             generate_description=False,
             title=title,
+            show_params=show_params,
         )
         for config in run_test_configs
     ]
@@ -253,7 +255,9 @@ def _run_comparison_test(
     else:
         test_doc = describe_test(test_id, raw=True)["Description"]
 
-    combined_outputs, combined_inputs, combined_params = combine_results(results)
+    combined_outputs, combined_inputs, combined_params = combine_results(
+        results, show_params
+    )
 
     return build_test_result(
         outputs=combined_outputs,
@@ -297,6 +301,7 @@ def run_test(  # noqa: C901
     generate_description: bool = True,
     title: Optional[str] = None,
     post_process_fn: Union[Callable[[TestResult], None], None] = None,
+    show_params: bool = True,
     **kwargs,
 ) -> TestResult:
     """Run a ValidMind or custom test
@@ -321,6 +326,7 @@ def run_test(  # noqa: C901
         generate_description (bool, optional): Whether to generate a description. Defaults to True.
         title (str, optional): Custom title for the test result
         post_process_fn (Callable[[TestResult], None], optional): Function to post-process the test result
+        show_params (bool, optional): Whether to include parameter values in figure titles for comparison tests. Defaults to True.
 
     Returns:
         TestResult: A TestResult object containing the test results
@@ -358,6 +364,7 @@ def run_test(  # noqa: C901
             input_grid=input_grid,
             params=params,
             param_grid=param_grid,
+            show_params=show_params,
         )
 
     elif unit_metrics:


### PR DESCRIPTION
## Internal Notes for Reviewers
**Fix for `param_grid` list of dictionaries**
Fixed a bug where passing a list of dictionaries to `param_grid` would incorrectly generate a cartesian product of all parameter values. Now, each dictionary in the list is correctly treated as a distinct test configuration, eliminating duplicated test combinations.

**Allow `param_grid` values to be displayed in figure titles**
Added a new `show_params` option to `run_test()` that enables parameter values to be displayed in figure titles for comparison tests. When enabled, figure titles now include parameter information, making it easier to distinguish between different test configurations in visualizations. The default value is `show_params=True`. If parameter values are causing the titles to become cluttered or difficult to read, the user can set `show_params=False` to prevent these values from being displayed.



<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `breaking-change`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->
