### PR TITLE
[SC 9567] Add text support in the test result object

### DIFF
--- a/validmind/tests/run.py
+++ b/validmind/tests/run.py
@@ -390,15 +390,16 @@ def run_test(  # noqa: C901
     if post_process_fn:
         result = post_process_fn(result)
 
-    result.description = get_result_description(
-        test_id=test_id,
-        test_description=result.doc,
-        tables=result.tables,
-        figures=result.figures,
-        metric=result.metric,
-        should_generate=generate_description,
-        title=title,
-    )
+    if not result.description:
+        result.description = get_result_description(
+            test_id=test_id,
+            test_description=result.doc,
+            tables=result.tables,
+            figures=result.figures,
+            metric=result.metric,
+            should_generate=generate_description,
+            title=title,
+        )
 
     if show:
         result.show()

--- a/validmind/vm_models/result/result.py
+++ b/validmind/vm_models/result/result.py
@@ -464,7 +464,7 @@ class TestResult(Result):
                 )
             )
 
-        if self.tables or self.figures:
+        if self.tables or self.figures or self.description:
             tasks.append(
                 api_client.alog_test_result(
                     result=self.serialize(),


### PR DESCRIPTION
## External Release Notes

We now support text output in test results.
If a test returns a string, this string will be used as the test description. In such cases, the automatic generation of the test result description will be skipped, and the test output will be used directly.

```python
@vm.test("my_custom_tests.MyCustomTest")
def my_custom_test(dataset, model):
    """
    This is a custom test that does nothing.
    """
    y_true = dataset.y
    y_pred = dataset.y_pred(model)

    confusion_matrix = metrics.confusion_matrix(y_true, y_pred)

    cm_display = metrics.ConfusionMatrixDisplay(
        confusion_matrix=confusion_matrix, display_labels=[False, True]
    )
    cm_display.plot()

    plt.close()  # close the plot to avoid displaying it



    return cm_display.figure_, "Test Description - Confusion Matrix", pd.DataFrame({"Value": [1, 2, 3]})  # return the figure object itself
```

### Run test

```python
from validmind.tests import run_test

result = run_test(
    "my_custom_tests.MyCustomTest",
    inputs={"model": "model", "dataset": "test_dataset"},
)
```

### Output

![image](https://github.com/user-attachments/assets/4a672219-4f0b-401e-b6ee-e46468b5a56d)

