### PR TITLE
[SC 9539] Keep order of the sections while previewing the template

### DIFF
--- a/validmind/template.py
+++ b/validmind/template.py
@@ -53,8 +53,9 @@ def _convert_sections_to_section_tree(
 
     if start_section_id and not section_tree:
         raise ValueError(f"Section {start_section_id} not found in template")
-
-    return sorted(section_tree, key=lambda x: x.get("order", 0))
+    # sort the section tree by the order of the sections in the template (if provided)
+    # set the order to 9999 for the sections that do not have an order
+    return sorted(section_tree, key=lambda x: x.get("order", 9999))
 
 
 def _create_content_widget(content: Dict[str, Any]) -> Widget:


### PR DESCRIPTION
## Internal Notes for Reviewers
When you call `preview_template()` for model documentation, validation reports, or ongoing monitoring reports, it will spit out the preview with the sections ordered as they are displayed in the YAML instead of honouring the custom `order` specified. **For example:**

| Custom Template Order | Incorrect Preview |
|---|---|
| ![image](https://github.com/user-attachments/assets/f76b612b-ff8e-434d-bddf-6376d57b497e)| ![image](https://github.com/user-attachments/assets/ef901437-eccf-45d9-87ab-d8aa758803f8)|

This change will sort the section tree by the order of the sections in the template (if provided) and set the order to 9999 for the sections that do not have an order.