### PR TITLE
delete test_get_metadata test

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -145,19 +145,6 @@ class TestAPIClient(unittest.TestCase):
             },
         )
 
-    @patch("aiohttp.ClientSession.get")
-    def test_get_metadata(self, mock_get: MagicMock):
-        res_json = [{"cuid": "1234"}]
-        mock_get.return_value = MockAsyncResponse(200, json=res_json)
-
-        response = self.run_async(api_client.aget_metadata, "content_id")
-
-        url = f"{os.environ['VM_API_HOST']}/get_metadata/content_id"
-        url += f""
-        mock_get.assert_called_with(url)
-
-        self.assertEqual(response, res_json)
-
     @patch("aiohttp.ClientSession.post")
     def test_log_figure_matplot(self, mock_post: MagicMock):
         mock_post.return_value = MockAsyncResponse(200, json={"cuid": "1234"})


### PR DESCRIPTION
## Internal Notes for Reviewers

- deleted `test_get_metadata` as the endpoint was not used in lib.
- deleted as well from backend

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `breaking-change`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->
