### PR TITLE
[SC-10190] Git ignore .direnv/ and .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,8 @@ ENV/
 env.bak/
 venv.bak/
 dev.env
+.envrc
+.direnv/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
# Pull Request Description

## What
This PR adds `.direnv/` and `.envrc` to `.gitignore`. Direnv https://direnv.net/ is a handy way to have per-project environment variables and other environment artifacts and load them when `cd`ing into a project.

## Why
Besides the fact that it's annoying to have files show up as untracked in git, VSCode search automatically excludes files and folders based on the git ignore. My environment populates `.direnv/` with temporary files from the project and should not show up in VSCode search.

## How to Test
`touch .envrc && git status | grep .envrc`

## Checklist
- [x] PR body describes what, why, and how to test
- [x] Breaking changes identified
- [x] Labels applied
- [x] PR linked to Shortcut
- [x] Tested locally
- [x] Documentation updated (if required)
